### PR TITLE
fix: refactor subprocess command construction for clarity

### DIFF
--- a/extern/threestudio/gradio_app.py
+++ b/extern/threestudio/gradio_app.py
@@ -207,22 +207,28 @@ def run(
 
     # spawn the training process
     gpu = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
-    process = subprocess.Popen(
-        f"python launch.py --config {config_file.name} --train --gpu {gpu} --gradio trainer.enable_progress_bar=false".split()
-        + [
-            f'name="{name}"',
-            f'tag="{tag}"',
-            f"exp_root_dir={os.path.join(save_root, EXP_ROOT_DIR)}",
-            "use_timestamp=false",
-            f'system.prompt_processor.prompt="{prompt}"',
-            f"system.guidance.guidance_scale={guidance_scale}",
-            f"seed={seed}",
-            f"trainer.max_steps={max_steps}",
-        ]
-        + (
-            ["checkpoint.every_n_train_steps=${trainer.max_steps}"] if save_ckpt else []
-        ),
-    )
+    cmd = [
+        "python",
+        "launch.py",
+        "--config",
+        config_file.name,
+        "--train",
+        "--gpu",
+        gpu,
+        "--gradio",
+        "trainer.enable_progress_bar=false",
+        f"name={name}",
+        f"tag={tag}",
+        f"exp_root_dir={os.path.join(save_root, EXP_ROOT_DIR)}",
+        "use_timestamp=false",
+        f"system.prompt_processor.prompt={prompt}",
+        f"system.guidance.guidance_scale={guidance_scale}",
+        f"seed={seed}",
+        f"trainer.max_steps={max_steps}",
+    ]
+    if save_ckpt:
+        cmd.append("checkpoint.every_n_train_steps=${trainer.max_steps}")
+    process = subprocess.Popen(cmd)
 
     # spawn the watcher process
     watch_process = subprocess.Popen(


### PR DESCRIPTION

https://github.com/Roblox/FlashTex/blob/adf34598db7a6b032e1b7d1c499cadd3cb68cf16/extern/threestudio/gradio_app.py#L210-L225

Code that passes user input directly to exec, eval, or some other library routine that executes a command, allows the user to execute malicious code. The following shows two functions. The first is unsafe as it takes a shell script that can be changed by a user, and passes it straight to subprocess.call() without examining it first. The second is safe as it selects the command from a predefined allowlist.
```
urlpatterns = [
    # Route to command_execution
    url(r'^command-ex1$', command_execution_unsafe, name='command-execution-unsafe'),
    url(r'^command-ex2$', command_execution_safe, name='command-execution-safe')
]

COMMANDS = {
    "list" :"ls",
    "stat" : "stat"
}

def command_execution_unsafe(request):
    if request.method == 'POST':
        action = request.POST.get('action', '')
        subprocess.call(["application", action])

def command_execution_safe(request):
    if request.method == 'POST':
        action = request.POST.get('action', '')
        subprocess.call(["application", COMMANDS[action]])
```


fix Avoid building the command as a single formatted string that depends on user input and then calling `.split()`. Instead, construct the `Popen` argument list explicitly, with each argument as a separate list element. This way, user-provided values (prompt, guidance scale, seed, max steps, save root) are passed as data-only arguments and cannot influence how the command is parsed. Optionally, lightly validate or constrain some values (e.g., numeric ranges are already constrained by sliders and types) but the key security fix is to eliminate string-splitting of a composite command.

Concrete best fix in this file:

- In `run(...)` around line 209–225, replace the `subprocess.Popen` call that uses:

  ```py f"python launch.py --config {config_file.name} --train --gpu {gpu} --gradio trainer.enable_progress_bar=false".split()
  + [f'name="{name}"', ...] ```

  with code that explicitly builds a list of arguments, e.g.:

  ```py
  cmd = [
      "python",
      "launch.py",
      "--config", config_file.name,
      "--train",
      "--gpu", gpu,
      "--gradio",
      "trainer.enable_progress_bar=false",
      f'name={name}',
      f'tag={tag}',
      ...
  ]
  subprocess.Popen(cmd)
  ```

- Keep the same semantics for quotes in the config values. Currently the code builds arguments like `name="foo"`, which are then split into a single argv element. When we move to an explicit list, we can safely drop the extra quoting and just pass `name=foo`, which `launch.py` will receive identically (as one argument) because there is no shell. This avoids complications with user-supplied quotes in `prompt`. If you must retain exact formatting, you can still include the quotes inside the single argument, but they are no longer interpreted by a shell; they are just characters.

- No new imports are needed; we continue to use `subprocess`.

This fix addresses all five alert variants because all tainted values that CodeQL tracks (prompt, guidance scale, seed, max steps, save_root) will now be passed as separate list elements, not used to construct or split the main command string.